### PR TITLE
Fixed ICanHaz example in chapter 8

### DIFF
--- a/ch08-templating.md
+++ b/ch08-templating.md
@@ -26,8 +26,8 @@ Is read by ICanHaz and turned into a function you call with your own like this:
 ```javascript
 // Your data
 var data = {
-  first_name: "Henrik",
-  last_name: "Joreteg"
+  name: "Henrik Joreteg",
+  twitter: "henrikjoreteg"
 }
 
 // I can has user??


### PR DESCRIPTION
Changed the object passed to the template in the ICanHaz example in chapter 8 to match the keys in the template.